### PR TITLE
Fix/handshake error

### DIFF
--- a/src/handshake/crypto.js
+++ b/src/handshake/crypto.js
@@ -188,8 +188,8 @@ exports.generateKeys = (state, callback) => {
       log('2.3. mac + cipher')
 
       parallel([
-        (cb) => support.makeMacAndCipher(state.protocols.local, cb),
-        (cb) => support.makeMacAndCipher(state.protocols.remote, cb)
+        (_cb) => support.makeMacAndCipher(state.protocols.local, _cb),
+        (_cb) => support.makeMacAndCipher(state.protocols.remote, _cb)
       ], cb)
     }
   ], callback)

--- a/src/handshake/exchange.js
+++ b/src/handshake/exchange.js
@@ -11,7 +11,7 @@ log.error = debug('libp2p:secio:error')
 
 // step 2. Exchange
 // -- exchange (signed) ephemeral keys. verify signatures.
-module.exports = function exchange (state, cb) {
+module.exports = function exchange (state, callback) {
   log('2. exchange - start')
 
   log('2. exchange - writing exchange')
@@ -27,9 +27,9 @@ module.exports = function exchange (state, cb) {
     },
     (cb) => crypto.generateKeys(state, cb)
   ], (err) => {
-    if (err) { return cb(err) }
+    if (err) { return callback(err) }
 
     log('2. exchange - finish')
-    cb()
+    callback()
   })
 }

--- a/src/handshake/finish.js
+++ b/src/handshake/finish.js
@@ -12,7 +12,7 @@ const crypto = require('./crypto')
 
 // step 3. Finish
 // -- send expected message to verify encryption works (send local nonce)
-module.exports = function finish (state, cb) {
+module.exports = function finish (state, callback) {
   log('3. finish - start')
 
   const proto = state.protocols
@@ -40,7 +40,7 @@ module.exports = function finish (state, cb) {
         sink (read) {
         }
       })
-      cb(err)
+      callback(err)
     }
 
     if (err) return fail(err)
@@ -55,6 +55,6 @@ module.exports = function finish (state, cb) {
 
     // Awesome that's all folks.
     state.secure.resolve(shake.handshake.rest())
-    cb()
+    callback()
   })
 }

--- a/src/handshake/index.js
+++ b/src/handshake/index.js
@@ -24,7 +24,7 @@ module.exports = function handshake (state, callback) {
     }
 
     // signal when the handshake is finished so that plumbing can happen
-    callback()
+    callback(err)
   })
 
   return state.stream

--- a/src/handshake/propose.js
+++ b/src/handshake/propose.js
@@ -11,7 +11,7 @@ log.error = debug('libp2p:secio:error')
 
 // step 1. Propose
 // -- propose cipher suite + send pubkeys + nonce
-module.exports = function propose (state, cb) {
+module.exports = function propose (state, callback) {
   log('1. propose - start')
 
   log('1. propose - writing proposal')
@@ -26,10 +26,10 @@ module.exports = function propose (state, cb) {
     (cb) => crypto.selectProtocols(state, cb)
   ], (err) => {
     if (err) {
-      return cb(err)
+      return callback(err)
     }
 
     log('1. propose - finish')
-    cb()
+    callback()
   })
 }


### PR DESCRIPTION
Callback naming was inconsistent in some of the files so I cleaned those up to help make them easier to read and avoid any potential hoisting issues.

Errors in the handshake weren't being passed back to `finish`, so if I handshake failed early enough that a peer id was not attained, it would cause an Assertion error attempting to set the peer info of the encrypted connection.

fixes ipfs/js-ipfs#1221