### PR TITLE
Support public key inlined peer IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@arve.knudsen/multihashes": "~0.4.15",
+    "multihashes": "~0.4.15",
     "async": "^2.6.2",
     "debug": "^4.1.1",
     "interface-connection": "~0.3.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@arve.knudsen/multihashes": "~0.4.15",
     "async": "^2.6.2",
     "debug": "^4.1.1",
     "interface-connection": "~0.3.3",

--- a/src/handshake/crypto.js
+++ b/src/handshake/crypto.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const mh = require('@arve.knudsen/multihashes')
+const mh = require('multihashes')
 const protons = require('protons')
 const PeerId = require('peer-id')
 const crypto = require('libp2p-crypto')


### PR DESCRIPTION
Support peer IDs derived from inlined public keys, as Go peers may produce these.