### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "it-pair": "^1.0.0",
     "it-pb-rpc": "^0.1.4",
     "it-pipe": "^1.1.0",
-    "libp2p-crypto": "~0.17.1",
-    "libp2p-interfaces": "~0.1.3",
+    "libp2p-crypto": "^0.17.1",
+    "libp2p-interfaces": "^0.2.1",
     "multiaddr": "^7.2.1",
-    "multihashing-async": "~0.8.0",
-    "peer-id": "~0.13.5",
-    "protons": "^1.0.1"
+    "multihashing-async": "^0.8.0",
+    "peer-id": "^0.13.6",
+    "protons": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^20.4.1",
+    "aegir": "^20.5.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",


### PR DESCRIPTION
The notable update here is the bump to `libp2p-interfaces@0.2.1`. Secio was using an error that was not yet exported, the version bump fixes that.