### PR TITLE
Populate the remote public key consistently

### DIFF
--- a/src/handshake/crypto.js
+++ b/src/handshake/crypto.js
@@ -68,6 +68,7 @@ exports.identify = async (state, msg) => {
     if (state.id.remote.toString() !== remoteId.toString()) {
       throw new UnexpectedPeerError('Dialed to the wrong peer: IDs do not match!')
     }
+    state.id.remote.pubKey = state.key.remote
   } else {
     state.id.remote = remoteId
   }


### PR DESCRIPTION
This change populates the public key of the remote peer if it already exists. This creates parity with the case where the remote peer does not exist.

See https://github.com/libp2p/js-peer-id/issues/123