### PR TITLE
fix: return public key

### DIFF
--- a/src/handshake/crypto.js
+++ b/src/handshake/crypto.js
@@ -68,6 +68,7 @@ exports.identify = async (state, msg) => {
     if (state.id.remote.toString() !== remoteId.toString()) {
       throw new UnexpectedPeerError('Dialed to the wrong peer: IDs do not match!')
     }
+    state.id.remote.pubKey = state.key.remote
   } else {
     state.id.remote = remoteId
   }


### PR DESCRIPTION
This adds a test to https://github.com/libp2p/js-libp2p-secio/pull/119 and supersedes it. Due to some rebasing issues I couldn't push an update to that PR. I cherry picked the test to master locally and verified the tests exposed the failure for outbound connections.